### PR TITLE
Add double buffered canvas support

### DIFF
--- a/simpleheat.js
+++ b/simpleheat.js
@@ -16,6 +16,11 @@ function simpleheat(canvas) {
     this._width = canvas.width;
     this._height = canvas.height;
 
+    this._bufferedCanvas = document.createElement('canvas');
+    this._bufferedCanvas.width = canvas.width;
+    this._bufferedCanvas.height = canvas.height;
+    this._bufferedCtx = this._bufferedCanvas.getContext('2d');
+
     this._max = 1;
     this._data = [];
 }
@@ -103,20 +108,20 @@ simpleheat.prototype = {
             this.gradient(this.defaultGradient);
         }
 
-        var ctx = this._ctx;
+        var ctx = this._ctx, bufferedCtx = this._bufferedCtx;
 
-        ctx.clearRect(0, 0, this._width, this._height);
+        bufferedCtx.clearRect(0, 0, this._width, this._height);
 
         // draw a grayscale heatmap by putting a blurred circle at each data point
         for (var i = 0, len = this._data.length, p; i < len; i++) {
             p = this._data[i];
 
-            ctx.globalAlpha = Math.max(p[2] / this._max, minOpacity === undefined ? 0.05 : minOpacity);
-            ctx.drawImage(this._circle, p[0] - this._r, p[1] - this._r);
+            bufferedCtx.globalAlpha = Math.max(p[2] / this._max, minOpacity === undefined ? 0.05 : minOpacity);
+            bufferedCtx.drawImage(this._circle, p[0] - this._r, p[1] - this._r);
         }
 
         // colorize the heatmap, using opacity value of each pixel to get the right color from our gradient
-        var colored = ctx.getImageData(0, 0, this._width, this._height);
+        var colored = bufferedCtx.getImageData(0, 0, this._width, this._height);
         this._colorize(colored.data, this._grad);
         ctx.putImageData(colored, 0, 0);
 


### PR DESCRIPTION
Hello I just found two issue in this project.

First is this file couldn't work on Windows Chrome (just test v40 stable and v41 beta), I guess clearRect seems doesn't work correctly some time, it will cause the heatmap become heater and heater, and finally all color became red. If you want to reproduce it, switch to Windows PC and Chrome, revert this patch, set a breakpoint on line 120, you will have a great chance to see colored circle still exist after clearRect. But if you set a breakpoint on line 119, you cannot reproduce it anymore.
I think it's a Chrome-side bug (and may related with OpenGL or other acculturate mechanism), but I can't reproduced it by using more clear way. So I can't fill a bug on Chrome issue tracker. But fortunately, this patch seems fixed this issue.

Second is rendering frequently will cause flicker, it's clearly that use double buffered canvas can fix this issue, so I added a in-memory canvas as a buffered canvas, test shows it works fine and even fixed previous issue, so I uploaded this patch and hope it can be merged it to main project.

Thanks!
