### PR TITLE
Add guard around zero width or height

### DIFF
--- a/simpleheat.js
+++ b/simpleheat.js
@@ -111,9 +111,11 @@ simpleheat.prototype = {
         }
 
         // colorize the heatmap, using opacity value of each pixel to get the right color from our gradient
-        var colored = ctx.getImageData(0, 0, this._width, this._height);
-        this._colorize(colored.data, this._grad);
-        ctx.putImageData(colored, 0, 0);
+        if(this._width!=0 && this._height!=0) {
+            var colored = ctx.getImageData(0, 0, this._width, this._height);
+            this._colorize(colored.data, this._grad);
+            ctx.putImageData(colored, 0, 0);
+        }
 
         return this;
     },


### PR DESCRIPTION
in my usage of this via leaflet.heat I have a lifecycle where the canvas can be 0 width or 0 height which is causing getImageData to throw an error.
I placed a guard around the relevant section so this case is covered.
If you can accept this request I will contact the leaflet.heat upstream and ask for them to propagate the update to their release.